### PR TITLE
Remove custom VPC

### DIFF
--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -46,28 +46,6 @@ else
   echo $message
 fi
 
-STACK_NAME="vpc"
-CF_TEMPLATE="$STACK_NAME.yml"
-echo -e "\nDeploying CF template $CF_BUCKET_URL/$CF_TEMPLATE"
-UPDATE_CMD="aws cloudformation update-stack \
---stack-name $STACK_NAME \
---capabilities CAPABILITY_NAMED_IAM \
---notification-arns $CloudformationNotifyLambdaTopicArn \
---template-url $CF_BUCKET_URL/$CF_TEMPLATE \
---parameters \
-ParameterKey=VpcSubnetPrefix,ParameterValue=\"$VpcSubnetPrefix\""
-message=$($UPDATE_CMD 2>&1 1>/dev/null)
-error_code=$(echo $?)
-if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
-  echo -e "\nNo stack changes detected. An update is not required."
-  error_code=0
-elif [[ $error_code -ne 0 ]]; then
-  echo $message
-  exit $error_code
-else
-  echo $message
-fi
-
 STACK_NAME="accounts"
 CF_TEMPLATE="$STACK_NAME.yml"
 echo -e "\nDeploying CF template cf_templates/$CF_TEMPLATE"


### PR DESCRIPTION
The sophos template[1] that was used to create the "sophos-utm" stack
creats a custom VPC with two subnets therefore we do not need to create
another custom VPC

[1] https://s3.amazonaws.com/sophos-nsg-cf/utm/autoscaling.template