### PR TITLE
Set default value for basicCountry

### DIFF
--- a/cf_templates/autoscaling.template
+++ b/cf_templates/autoscaling.template
@@ -338,7 +338,8 @@
         "South Africa",
         "Zambia",
         "Zimbabwe"
-      ]
+      ],
+      "Default": "United States"
     },
     "awsKeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access.",

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -88,7 +88,6 @@ ParameterKey=basicAdminEmail,ParameterValue=\"$OperatorEmail\" \
 ParameterKey=basicAdminPassword,ParameterValue=\"$SophosInitAdminPassword\" \
 ParameterKey=basicOrganization,ParameterValue="Sage-Bionetworks" \
 ParameterKey=basicCity,ParameterValue="Seattle" \
-ParameterKey=basicCountry,ParameterValue="'United\ States'" \
 ParameterKey=awsKeyName,ParameterValue="sophosutm" \
 ParameterKey=debugMode,ParameterValue="on""
 message=$($UPDATE_CMD 2>&1 1>/dev/null)


### PR DESCRIPTION
Can't figure out how to escape spaces in aws cloudformation CLI
ParameterValues.  Workaround is to set a default value for
basicCountry.