### PR TITLE
Automate VPC Peering request

### DIFF
--- a/cf_templates/VPCPeer.yml
+++ b/cf_templates/VPCPeer.yml
@@ -152,3 +152,5 @@ Outputs:
     Value: !GetAtt
       - CreateVPCPeer
       - VPCRequestId
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-VPCRequestId'

--- a/cf_templates/VPCPeer.yml
+++ b/cf_templates/VPCPeer.yml
@@ -1,0 +1,154 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template create a lambda function and use it to generate a cross account
+  VPC Peer request , the destination account must have created the role to
+  authorize the VPC Peer request
+Metadata: {}
+Parameters:
+  LocalVPC:
+    Description: Local VPC ID
+    Type: String
+  PeerVPC:
+    Description: VPC ID in the peer account
+    Type: String
+  PeerVPCOwner:
+    Description: Account ID of the peer account
+    Type: String
+  PeerRoleName:
+    Description: Role Name on the peer account
+    Type: String
+Resources:
+  CreateVPCPeer:
+    DependsOn:
+      - LambdaVPCPeer
+    Type: 'Custom::VPCPeer'
+    Version: '1.0'
+    Properties:
+      ServiceToken: !GetAtt
+        - LambdaVPCPeer
+        - Arn
+      LocalVPC: !Ref LocalVPC
+      PeerVPC: !Ref PeerVPC
+      PeerVPCOwner: !Ref PeerVPCOwner
+      PeerRoleName: !Ref PeerRoleName
+  LambdaVPCPeer:
+    DependsOn:
+      - LambdaExecutionRole
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: index.vpc_request
+      Role: !GetAtt
+        - LambdaExecutionRole
+        - Arn
+      Code:
+        ZipFile: !Join
+          - |+
+
+          - - import json
+            - import cfnresponse
+            - import boto3
+            - import logging
+            - import time
+            - logger = logging.getLogger()
+            - logger.setLevel(logging.DEBUG)
+            - 'def vpc_request(event, context):'
+            - '  ec2 = boto3.resource(''ec2'')'
+            - '  PayLoad = {}'
+            - '  if event[''RequestType''] == ''Delete'':'
+            - '    PayLoad[''VPCRequestId''] = event[''PhysicalResourceId'']'
+            - '    PayLoad[''SubStatus''] = ''DELETED'''
+            - '    logging.info(''Delete Request'')'
+            - '    vpcrm = ec2.VpcPeeringConnection(event[''PhysicalResourceId''])'
+            - '    try:'
+            - '      vpcrm.delete()'
+            - '    except Exception as e:'
+            - '      logging.info(''Cant delete vpc peer'')'
+            - '    time.sleep(1)'
+            - '    cfnresponse.send(event, context, cfnresponse.SUCCESS, PayLoad, event[''PhysicalResourceId''])'
+            - '    return PayLoad'
+            - '  logging.info(''Creating VPC Request'')'
+            - '  try:'
+            - '    logging.debug(event)'
+            - '    logging.info(event[''ResourceProperties''][''PeerVPC''])'
+            - '    if (''LocalVPC'' not in event[''ResourceProperties''] or'
+            - '      ''PeerVPC'' not in event[''ResourceProperties''] or'
+            - '      ''PeerVPCOwner'' not in event[''ResourceProperties'']):'
+            - '      logging.info(''No ResourceProperties Internal'')'
+            - '      cfnresponse.send(event, context, cfnresponse.FAILED, PayLoad)'
+            - '      return'
+            - '    localVPC = event[''ResourceProperties''][''LocalVPC'']'
+            - '    PeerVPC = event[''ResourceProperties''][''PeerVPC'']'
+            - '    PeerVPCOwner = event[''ResourceProperties''][''PeerVPCOwner'']'
+            - '    vpcrequest = ec2.create_vpc_peering_connection(VpcId=localVPC,'
+            - '      PeerVpcId=PeerVPC,'
+            - '      PeerOwnerId=PeerVPCOwner)'
+            - '    PayLoad[''VPCRequestId''] = vpcrequest.id'
+            - '  except Exception as e:'
+            - '    logging.error(''VPCPeer Request Failed (%s)'', e)'
+            - '    cfnresponse.send(event, context, cfnresponse.FAILED, PayLoad)'
+            - '    return False'
+            - '  logging.info(''Switching to the peer account to authorize VPCPeer %s'' % vpcrequest.id)'
+            - '  try:'
+            - '    sts_client = boto3.client(''sts'')'
+            - '    LocalRoleArn = ("arn:aws:iam::%s:role/%s" %'
+            - '      (event[''ResourceProperties''][''PeerVPCOwner''],'
+            - '        event[''ResourceProperties''][''PeerRoleName'']))'
+            - '    assumedRoleObject = sts_client.assume_role('
+            - '      RoleArn=LocalRoleArn,'
+            - '      RoleSessionName="RoleToAuthorizeVPCPeer")'
+            - '    credentials = assumedRoleObject[''Credentials'']'
+            - '  except Exception as  e:'
+            - '    logging.error(''STS Failed (%s)'', e)'
+            - '    cfnresponse.send(event, context, cfnresponse.FAILED, PayLoad)'
+            - '    return False'
+            - '  logging.info(''Authorizing VPCPeer %s'' % vpcrequest.id)'
+            - '  try:'
+            - '    ec2_other = boto3.resource(''ec2'','
+            - '      aws_access_key_id = credentials[''AccessKeyId''],'
+            - '      aws_secret_access_key = credentials[''SecretAccessKey''],'
+            - '      aws_session_token = credentials[''SessionToken''])'
+            - '    vpcauth = ec2_other.VpcPeeringConnection(vpcrequest.id)'
+            - '    vpcauth.accept()'
+            - '  except Exception as e:'
+            - '    logging.error(''VPCPeer Auth Failed (%s)'', e)'
+            - '    cfnresponse.send(event, context, cfnresponse.FAILED,PayLoad)'
+            - '    return False'
+            - '  cfnresponse.send(event, context, cfnresponse.SUCCESS, PayLoad, vpcrequest.id)'
+            - '  return PayLoad'
+      Runtime: python2.7
+      Timeout: '10'
+  LambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+              - Effect: Allow
+                Action:
+                  - 'ec2:CreateVpcPeeringConnection'
+                  - 'ec2:DeleteVpcPeeringConnection'
+                  - 'sts:AssumeRole'
+                Resource: '*'
+Outputs:
+  VPCPeerId:
+    Description: This Is the VPC Peer Id Created by the Template
+    Value: !GetAtt
+      - CreateVPCPeer
+      - VPCRequestId


### PR DESCRIPTION
When you request a VPC peering connection from one AWS account
(requester_account) to a VPC in another AWS account (a peer_account),
the VPC peering connection request must first be approved and accepted
by the peer_account to be activated. By default, the requester_account
cannot both request and also approve VPC peering connection requests
made to a different AWS peer_account. AWS knowledge base article[1]
explain how to automate the approval of a peering request. This CF
template code is from the awslabs repo[2].

This template should be executed for each peering request.

[1] https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-peering-vpc-different-account/
[2] https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/solutions/VPCPeering