### PR TITLE
Additional setup for sophos utm

### DIFF
--- a/cf_templates/autoscaling.template
+++ b/cf_templates/autoscaling.template
@@ -1997,7 +1997,17 @@
         "GroupDescription": "Enable HTTP access on port 8080",
         "VpcId": {
           "Ref": "VPC"
-        }
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": {
+              "Ref": "awsTrustedNetwork"
+            }
+          }
+        ]
       }
     },
     "ElasticLoadBalancer": {
@@ -2027,6 +2037,13 @@
             "LoadBalancerPort": "80",
             "InstancePort": "80",
             "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "443",
+            "Protocol": "HTTPS",
+            "SSLCertificateId": { "Fn::ImportValue" : us-east-1-sophos-pre-setup-Certificate },
+            "InstancePort": "80",
+            "InstanceProtocol": "HTTP"
           }
         ],
         "HealthCheck": {

--- a/cf_templates/sophos-post-setup.yml
+++ b/cf_templates/sophos-post-setup.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Template to complete sophos utm setup
+Resources:
+  HostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      HostedZoneConfig:
+        Comment: "Hosted zone for sagebase.org"
+      Name: "sagebase.org"
+      VPCs:
+        -
+          VPCId: !ImportValue "us-east-1-sophos-utm-VPCID"
+          VPCRegion: "us-east-1"
+      HostedZoneTags:
+        -
+          Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        -
+          Key: "Name"
+          Value: "VPN"
+  DnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: !Ref HostedZone
+      Name: !Join ['', ['vpn', ., !GetAtt 'HostedZone.NameServers']]
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+        - !ImportValue us-east-1-sophos-utm-PublicIPAddress
+      Tags:
+        -
+          Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        -
+          Key: "Name"
+          Value: "VPN DNS"
+Outputs:
+  HostedZone:
+    Value: !Ref HostedZone
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-HostedZone'
+  DnsRecord:
+    Value: !Ref DnsRecord
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DnsRecord'

--- a/cf_templates/sophos-pre-setup.yml
+++ b/cf_templates/sophos-pre-setup.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Template to create required resources for sophos utm
+Resources:
+  # Certificate creation requires a manual step, either email or dns approval
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: vpn.sagebase.org
+      Tags:
+        -
+          Key: "Application"
+          Value:
+            Ref: "AWS::StackName"
+        -
+          Key: "Name"
+          Value: "VPN Cert"
+Outputs:
+  Certificate:
+    Value: !Ref Certificate
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Certificate'


### PR DESCRIPTION
Add additional resources for sophos utm

Pre setup
* create an SSL certificate (requires manual approval)

Sophos resources
* provide HTTPS access on port 443 with vpn.sagebase.org certificate

Post setup
* setup sagebase.org hosted zone
* setup record set for vpn.sagebase.org