### PR TITLE
Rename LocalVPC param

### DIFF
--- a/cf_templates/VPCPeer.yml
+++ b/cf_templates/VPCPeer.yml
@@ -5,9 +5,10 @@ Description: >-
   authorize the VPC Peer request
 Metadata: {}
 Parameters:
-  LocalVPC:
-    Description: Local VPC ID
+  SophosVPC:
+    Description: The sophos-utm VPC ID
     Type: String
+    Default: "vpc-2135cc5a"
   PeerVPC:
     Description: VPC ID in the peer account
     Type: String
@@ -27,7 +28,7 @@ Resources:
       ServiceToken: !GetAtt
         - LambdaVPCPeer
         - Arn
-      LocalVPC: !Ref LocalVPC
+      LocalVPC: !Ref SophosVPC
       PeerVPC: !Ref PeerVPC
       PeerVPCOwner: !Ref PeerVPCOwner
       PeerRoleName: !Ref PeerRoleName


### PR DESCRIPTION
Since we are setting up a VPN gateway the source VPC will always be
the sophos-utm VPC therefore we can set it as the default.  Also
rename the parameter to have more meaning.