### PR TITLE
Fix template promotion

### DIFF
--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Need to upload TEMPLATES to S3 before validating due to template-body MAX 51K length
 # https://docs.aws.amazon.com/cli/latest/reference/cloudformation/validate-template.html#options
@@ -22,8 +23,12 @@ for f in $TEMPLATES
 do
   echo -e "\nValidating CF template $TEMPLATE_URL/$f"
   aws cloudformation validate-template --template-url $TEMPLATE_URL/$f
+done
+
+for f in $TEMPLATES
+do
+  echo -e "\nPromote CF template to https://s3.amazonaws.com/$S3_BUCKET/$S3_BUCKET_PATH/$f"
   aws s3 mv $S3_BUCKET_URL/$TEMP_DIR/$f $S3_BUCKET_URL/$f
 done
 
 popd
-


### PR DESCRIPTION
CF templates were gettting promoted even on validation errors.
Separate the validation and promotion step and make script stop
on any failure so that we either promote all templates or none.