### PR TITLE
move deployment of jumpcloud lambda

### DIFF
--- a/config/prod/jumpcloud.yaml
+++ b/config/prod/jumpcloud.yaml
@@ -1,0 +1,10 @@
+template_path: remote-templates/jumpcloud.yaml
+stack_name: jumpcloud
+dependencies:
+  - essentials
+parameters:
+  LambdaBucket: essentials-awss3lambdaartifactsbucket-x29ftznj6pqw
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+hooks:
+  before_update:
+    - !cmd "curl https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/jumpcloud.yaml --create-dirs -o remote-templates/jumpcloud.yaml"


### PR DESCRIPTION
move jumpcloud lambda deployment from scicomp-infra to
admincentral-infra since the lambda performs an IT
administrative task it makes more sense to deploy
from admincentral-infra.