### PR TITLE
[IT-446] validate templates on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,20 @@ python: 3.5
 cache: pip
 fast_finish: true
 install:
-- wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
-- unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
-- ./setup_aws_cli.sh || travis_terminate 1
-- ./setup_sceptre.sh || travis_terminate 1
-script:
-- ./validate-templates.sh || travis_terminate 1
-- sceptre --var "profile=default" --var "region=us-east-1" launch-env prod
-- ./deploy-sam-templates.sh || travis_terminate 1
-
+  - pip install cfn-lint
+  - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
+  - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
+  - ./setup_aws_cli.sh || travis_terminate 1
+  - ./setup_sceptre.sh || travis_terminate 1
+stages:
+  - name: validate
+  - name: deploy
+    if: branch = master AND type = push
+jobs:
+  include:
+    - stage: validate
+      script: cfn-lint ./templates/**/*.yaml
+    - stage: deploy
+      script:
+        - sceptre --var "profile=default" --var "region=us-east-1" launch-env prod
+        - ./deploy-sam-templates.sh || travis_terminate 1

--- a/templates/VPCPeer.yaml
+++ b/templates/VPCPeer.yaml
@@ -20,8 +20,6 @@ Parameters:
     Type: String
 Resources:
   CreateVPCPeer:
-    DependsOn:
-      - LambdaVPCPeer
     Type: 'Custom::VPCPeer'
     Version: '1.0'
     Properties:
@@ -33,8 +31,6 @@ Resources:
       PeerVPCOwner: !Ref PeerVPCOwner
       PeerRoleName: !Ref PeerRoleName
   LambdaVPCPeer:
-    DependsOn:
-      - LambdaExecutionRole
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: index.vpc_request
@@ -117,7 +113,7 @@ Resources:
             - '  cfnresponse.send(event, context, cfnresponse.SUCCESS, PayLoad, vpcrequest.id)'
             - '  return PayLoad'
       Runtime: python2.7
-      Timeout: '10'
+      Timeout: 10
   LambdaExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
Fix the following lint errors:

W3005 Obsolete DependsOn on resource (LambdaVPCPeer), dependency already enforced by a "Fn:GetAtt" at Resources/CreateVPCPeer/Properties/ServiceToken/Fn::GetAtt/['LambdaVPCPeer', 'Arn']
./templates/VPCPeer.yaml:23:5

W3005 Obsolete DependsOn on resource (LambdaExecutionRole), dependency already enforced by a "Fn:GetAtt" at Resources/LambdaVPCPeer/Properties/Role/Fn::GetAtt/['LambdaExecutionRole', 'Arn']
./templates/VPCPeer.yaml:36:5

E3012 Property Resources/LambdaVPCPeer/Properties/Timeout should be of type Integer
./templates/VPCPeer.yaml:120:7