### PR TITLE
remove jumpcloud cleanup

### DIFF
--- a/config/prod/jumpcloud.yaml
+++ b/config/prod/jumpcloud.yaml
@@ -1,9 +1,0 @@
-template_path: remote/jumpcloud.yaml
-stack_name: jumpcloud
-dependencies:
-  - prod/essentials.yaml
-parameters:
-  JcServiceApiKey: !ssm /infra/JcServiceApiKey
-hooks:
-  before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/jumpcloud.yaml --create-dirs -o templates/remote/jumpcloud.yaml"


### PR DESCRIPTION
Apparently cleaning systems from jumpcloud, which was done in PR
https://github.com/Sage-Bionetworks/aws-infra/pull/141
may have also told jumpcloud to remove the jc agent from instances.
We don't want to do that because inactive instances from a PMC park
may not work after it is un-parked.  We uninstall this lambda.