### PR TITLE
fix cfn-lint error

### DIFF
--- a/templates/VPCPeer.yaml
+++ b/templates/VPCPeer.yaml
@@ -12,6 +12,9 @@ Parameters:
   PeerVPCCIDR:
     Description: CIDR of the VPC in the peer account (i.e. 10.17.0.0/16)
     Type: String
+    MinLength: '9'
+    MaxLength: '18'
+    AllowedPattern: '(\d{1,3})\.(\d{1,3})\.0\.0/16'
   PeerVPCOwner:
     Description: Account ID of the peer account (i.e. 123456789123)
     Type: String


### PR DESCRIPTION
Fix the following cfn-lint error

$ cfn-lint ./templates/**/*
W2509 AllowedPattern and/or AllowedValues for Parameter should be
specified at Parameters/PeerVPCCIDR. Example for AllowedPattern:
'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
./templates/VPCPeer.yaml:12:3