### PR TITLE
Add CI service account for deploying Emory pipeline lambda function

### DIFF
--- a/config/prod/service-accounts-emorypipeline.yaml
+++ b/config/prod/service-accounts-emorypipeline.yaml
@@ -1,0 +1,4 @@
+template_path: service-accounts-emorypipeline.yaml
+stack_name: service-accounts-emorypipeline
+dependencies:
+  - prod/essentials.yaml

--- a/templates/service-accounts-emorypipeline.yaml
+++ b/templates/service-accounts-emorypipeline.yaml
@@ -1,0 +1,106 @@
+Description: Setup service account and roles for Emory pipeline lambda
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  # !! IMPORTANT !! - AWS API will refuse to remove users that have attached resources.
+  # Therefore you must do the following before deleting them from this file:
+  # 1. Detach or remove the following user resources: login profile, attached
+  #    MFA device, access-keys, ssh-keys, and policies.
+  # 2. Detach the user from all groups.
+  CfnDeployerServiceUser:
+    Type: 'AWS::IAM::User'
+  CfnDeployerServiceUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref CfnDeployerServiceUser
+  CfnDeployerServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      ManagedPolicyArns:
+        # AWSKeyManagementServicePowerUser allows users to list & describe all keys,
+        # but may only manage and use keys they create.
+        - arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt CfnDeployerServiceUser.Arn
+            Action:
+              - "sts:AssumeRole"
+  CfnDeployerServiceRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "deployer"
+      Roles:
+        - !Ref CfnDeployerServiceRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "CloudFormationExceptDelete"
+            Effect: Allow
+            NotAction:
+              - cloudformation:DeleteStack
+            Resource: '*'
+          - Sid: "S3ReadWriteCreate"
+            Action:
+              - s3:Get*
+              - s3:Put*
+              - s3:Create*
+            Effect: Allow
+            Resource: arn:aws:s3:::*
+          - Sid: "ManageLambdaFunctionRole"
+            Action:
+              - iam:CreateRole
+              - iam:CreatePolicy
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Effect: Allow
+            Resource:
+              - '*'
+          - Sid: "ManageSynapseCredentialsSecret"
+            Action:
+              - secretsmanager:CreateSecret
+              - secretsmanager:PutSecretValue
+              - secretsmanager:UpdateSecretValue
+              - secretsmanager:TagResource
+            Effect: Allow
+            Resource:
+              - '*'
+          - Sid: "ManageLambdaFunction"
+            Action:
+              - lambda:CreateFunction
+              - lambda:UpdateFunctionConfiguration
+              - lambda:UpdateFunctionCode
+              - lambda:AddPermission
+              - lambda:CreateEventSourceMapping
+            Effect: Allow
+            Resource:
+              - '*'
+
+Outputs:
+  CfnDeployerServiceUser:
+    Value: !Ref CfnDeployerServiceUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUser'
+  CfnDeployerServiceUserArn:
+    Value: !GetAtt CfnDeployerServiceUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserArn'
+  CfnDeployerServiceUserAccessKey:
+    Value: !Ref CfnDeployerServiceUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserAccessKey'
+  CfnDeployerServiceUserSecretAccessKey:
+    Value: !GetAtt CfnDeployerServiceUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserSecretAccessKey'
+  CfnDeployerServiceRole:
+    Value: !Ref CfnDeployerServiceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceRole'
+  CfnDeployerServiceRoleArn:
+    Value: !GetAtt CfnDeployerServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceRoleArn'


### PR DESCRIPTION
Using [PR 74](https://github.com/Sage-Bionetworks/admincentral-infra/pull/74) as a template, this creates a user and a role with the permissions needed to deploy the [Emory pipeline s3-to-synapse-lambda-code](https://github.com/Sage-Bionetworks/s3-to-synapse-lambda-code).

Travis CI should use this user and role when building the s3-to-synapse-lambda-code repo.