### PR TITLE
[SC-13] Install s3ojects macro

### DIFF
--- a/config/prod/cfn-s3objects-macro.yaml
+++ b/config/prod/cfn-s3objects-macro.yaml
@@ -1,0 +1,9 @@
+template_path: "remote/cfn-s3objects-macro.yaml"
+stack_name: "cfn-s3objects-macro"
+dependencies:
+  - "prod/bootstrap.yaml"
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"


### PR DESCRIPTION
The idea is to install this macro then use it to create a bucket that
contains files that can be included in cloudformation templates using
the AWS::Include transform.