### PR TITLE
[SC-13] Setup a bucket for CFN snippets

### DIFF
--- a/config/prod/cfn-snippets-bucket.yaml
+++ b/config/prod/cfn-snippets-bucket.yaml
@@ -1,0 +1,4 @@
+template_path: cfn-snippets-bucket.yaml
+stack_name: cfn-snippets-bucket
+dependencies:
+  - prod/cfn-s3objects-macro.yaml

--- a/templates/cfn-snippets-bucket.yaml
+++ b/templates/cfn-snippets-bucket.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: S3Objects
+Description: 'Cloudformation Snippets Bucket'
+Parameters:
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+Resources:
+  # Bucket for cloudformation snippets
+  CloudformationSnippetsBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+      Tags:
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  CloudformationSnippetsBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref CloudformationSnippetsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "AllowPublicRead"
+            Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${CloudformationSnippetsBucket}/*"
+  # requires the cloudformation S3 objects macro
+  # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro
+  ServiceCatalogSupportSnippet:
+    Type: AWS::S3::Object
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
+    Properties:
+      Target:
+        Bucket: !Ref CloudformationSnippetsBucket
+        Key: scipoolprod-sc-lib-infra/support.yaml
+        ContentType: text
+        ACL: public-read
+        Body: |
+          SupportDescription: Sage IT
+          SupportEmail: it@sagebase.org
+          AcceptLanguage: en
+          SupportUrl: https://sagebionetworks.slack.com/#sageit
+Outputs:
+  CloudformationSnippetsBucket:
+    Value: !Ref 'CloudformationSnippetsBucket'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudformationSnippetsBucket'
+  CloudformationSnippetsBucketArn:
+    Value: !GetAtt 'CloudformationSnippetsBucket.Arn'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CloudformationSnippetsBucketArn'


### PR DESCRIPTION
Create a bucket for cloudformation snippets.  Add a support
snippet to be included in the service catalog libraries.
This depends on PR https://github.com/Sage-Bionetworks/admincentral-infra/pull/76

Note from [AWS::Include docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)

```
If your snippets change, your stack doesn't automatically pick up those changes.
To get those changes, you must update the stack with the updated snippets.
If you update your stack, make sure your included snippets haven't changed
without your knowledge. To verify before updating the stack, check the change set.
```