### PR TITLE
Fix build failure caused by dependency version conflict 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - pip install cfn-lint sceptre sceptre-ssm-resolver
+  - pip install cfn-lint==0.28.0 sceptre sceptre-ssm-resolver
 stages:
   - name: validate
   - name: deploy


### PR DESCRIPTION
python package `networkx` is [pinned](https://github.com/aws-cloudformation/cfn-python-lint/commit/6ef3d9550ba7e9979c24cf3f9f54217b6ec4c562#diff-2eeaed663bd0d25b7e608891384b7298 ) to different versions depending on python version by `cfn-lint`. This causes conflicts with `sceptre`, which has it pinned to 2.1.

Pinning `cfn-lint` to `0.28.0` for now.