### PR TITLE
[IT-870] Bucket for IDP certs

### DIFF
--- a/config/prod/idp.yaml
+++ b/config/prod/idp.yaml
@@ -1,0 +1,4 @@
+template_path: "idp.yaml"
+stack_name: "idp"
+dependencies:
+  - prod/bootstrap.yaml

--- a/templates/idp.yaml
+++ b/templates/idp.yaml
@@ -1,0 +1,27 @@
+Description: Resources for AWS IDP providers
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  IdpBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+  IdpBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref IdpBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "AllowPublicRead"
+            Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "s3:GetObject"
+            Resource: !Sub "arn:aws:s3:::${IdpBucket}/*"
+Outputs:
+  IdpBucket:
+    Value: !Ref IdpBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-IdpBucket'


### PR DESCRIPTION
Setup a global public bucket to store IDP public certificates.
Initially this bucket will be used to store jumpcloud SAML certs
however I can see it being used to store other IDP certs as well.