### PR TITLE
Add iatlas VPC peer

### DIFF
--- a/config/prod/peering-iatlasvpc.yaml
+++ b/config/prod/peering-iatlasvpc.yaml
@@ -1,0 +1,7 @@
+template_path: VPCPeer.yaml
+stack_name: peering-atlasvpc
+parameters:
+  PeerVPC: "vpc-0e5befad4ce267f67"   # iatlastvpc ID
+  PeerVPCOwner: "055273631518"   # org-sagebase-scicomp account ID
+  PeerVPCCIDR: "10.255.20.0/24"    # iatlasvpc CIDR
+  PeerRoleName: "essentials-VPCPeeringAuthorizerRole-19X5D81TAK34F" #export role name in org-sagebase-scicomp essentials stack

--- a/config/prod/peering-iatlasvpc.yaml
+++ b/config/prod/peering-iatlasvpc.yaml
@@ -1,7 +1,7 @@
 template_path: VPCPeer.yaml
 stack_name: peering-atlasvpc
 parameters:
-  PeerVPC: "vpc-0e5befad4ce267f67"   # iatlastvpc ID
+  PeerVPC: "vpc-0e5befad4ce267f67"   # iatlasvpc ID
   PeerVPCOwner: "055273631518"   # org-sagebase-scicomp account ID
   PeerVPCCIDR: "10.255.20.0/24"    # iatlasvpc CIDR
   PeerRoleName: "essentials-VPCPeeringAuthorizerRole-19X5D81TAK34F" #export role name in org-sagebase-scicomp essentials stack


### PR DESCRIPTION
This will allow the new iatlasvpc to peer with admincentral using resources from essentials in the scicomp account.