### PR TITLE
Update regex in template pattern to allow mini-vpc subnetting

### DIFF
--- a/templates/VPCPeer.yaml
+++ b/templates/VPCPeer.yaml
@@ -10,11 +10,11 @@ Parameters:
     Description: VPC ID in the peer account (i.e. vpc-1234abcd)
     Type: String
   PeerVPCCIDR:
-    Description: CIDR of the VPC in the peer account (i.e. 10.17.0.0/16)
+    Description: CIDR of the VPC in the peer account (i.e. 10.17.0.0/16 or 10.255.17.0/24)
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    AllowedPattern: '(\d{1,3})\.(\d{1,3})\.0\.0/16'
+    AllowedPattern: '((\d{1,3})\.(\d{1,3})\.0\.0/16)|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.0/24)'
   PeerVPCOwner:
     Description: Account ID of the peer account (i.e. 123456789123)
     Type: String


### PR DESCRIPTION
Adding a peer to a mini vpc fails because the AllowPattern filter on the VPCPeer template requires a /16 input. This changes that regex to allow /16 or /24. I believe the rest of the template is agnostic at to the size of the CIDR block.