### PR TITLE
Update cloudformation deployer policy

### DIFF
--- a/templates/iam-policies.yaml
+++ b/templates/iam-policies.yaml
@@ -34,6 +34,12 @@ Resources:
                   - ''
                   - - 'Fn::ImportValue': !Sub '${AWS::Region}-essentials-LambdaArtifactsBucketArn'
                     - '/*'
+          - Effect: Allow
+            Sid: "Manage applications in serverless repository"
+            Action:
+              - "serverlessrepo:*"
+            Resource:
+              - !Sub "arn:aws:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*"
 Outputs:
   CfnDeployerServiceManagedPolicyArn:
     Value: !Ref CfnDeployerServiceManagedPolicy


### PR DESCRIPTION
The CfnDeployerServiceUser account is used to deploy cloudformation
templates and lambdas.  Give the user access to deploy and manage
lambdas in the AWS serverless repository.